### PR TITLE
satisfy `ts7016` error (when using `typescript@5.3.3`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "exports": {
     ".": {
       "import": "./lib/catenary-curve.js",
-      "require": "./lib/catenary-curve.umd.cjs"
+      "require": "./lib/catenary-curve.umd.cjs",
+      "types": "./lib/main.d.ts"
     }
   },
   "repository": "https://github.com/dulnan/catenary-curve",


### PR DESCRIPTION
Seeing the following error when using in a `vite@latest` app. Making this change to the `package.json` removes it (found some info [here](https://stackoverflow.com/a/77566206/8703073))

```
Could not find a declaration file for module 'catenary-curve'. '.../node_modules/catenary-curve/lib/catenary-curve.js' implicitly has an 'any' type.
  There are types at '.../node_modules/catenary-curve/lib/main.d.ts', but this result could not be resolved when respecting package.json "exports". The 'catenary-curve' library may need to update its package.json or typings.ts(7016)
```